### PR TITLE
fix soft keyboard submit of empty message

### DIFF
--- a/full_steps/step_0_offline/lib/main.dart
+++ b/full_steps/step_0_offline/lib/main.dart
@@ -123,7 +123,9 @@ class ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                     _isComposing = text.length > 0;
                   });
                 },
-                onSubmitted: _handleSubmitted,
+                onSubmitted: _isComposing
+                          ?_handleSubmitted
+                          :null,
                 decoration:
                     new InputDecoration.collapsed(hintText: "Send a message"),
               ),


### PR DESCRIPTION
The callback handleSubmitted could be called with empty text through soft keyboard submit. Added check for _isComposing in TextField's onSubmitted