### PR TITLE
add jitpack.io

### DIFF
--- a/full_steps/step_1_set_up_firebase/android/build.gradle
+++ b/full_steps/step_1_set_up_firebase/android/build.gradle
@@ -18,6 +18,9 @@ allprojects {
         maven {
             url "https://maven.google.com"
         }
+        maven {
+            url "https://jitpack.io"
+        }
     }
 }
 


### PR DESCRIPTION
I fixed because I could not execute `flutter run` on step_1_set_up_firebase.
It would be happy if you check it out .

```
xxxx:step_1_set_up_firebase yagi$ flutter run
Running "flutter packages get" in step_1_set_up_firebase...  3.1s
Launching lib/main.dart on E5823 in debug mode...
Initializing gradle...                                       0.8s
Resolving dependencies...                                    7.8s
Running 'gradlew assembleDebug'...                               

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/yagi/Works/friendlychat-steps/full_steps/step_1_set_up_firebase/android/build.gradle' line: 27

* What went wrong:
Could not determine the dependencies of task ':app:prepareDebugDependencies'.
> Could not resolve all task dependencies for configuration ':app:_debugApk'.
   > Could not find com.github.esafirm.android-image-picker:imagepicker:1.5.0.
     Searched in the following locations:
         https://jcenter.bintray.com/com/github/esafirm/android-image-picker/imagepicker/1.5.0/imagepicker-1.5.0.pom
         https://jcenter.bintray.com/com/github/esafirm/android-image-picker/imagepicker/1.5.0/imagepicker-1.5.0.aar
         https://maven.google.com/com/github/esafirm/android-image-picker/imagepicker/1.5.0/imagepicker-1.5.0.pom
         https://maven.google.com/com/github/esafirm/android-image-picker/imagepicker/1.5.0/imagepicker-1.5.0.aar
     Required by:
         project :app > project :image_picker

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s
Gradle build failed: 1
```