### PR TITLE
FIX: disable adding empty message using keyboard tick

### DIFF
--- a/offline_steps/step_5_finishing_touches/lib/main.dart
+++ b/offline_steps/step_5_finishing_touches/lib/main.dart
@@ -124,7 +124,7 @@ class ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                     _isComposing = text.length > 0;
                   });
                 },
-                onSubmitted: _handleSubmitted,
+                onSubmitted: _isComposing ? _handleSubmitted : null,
                 decoration:
                     new InputDecoration.collapsed(hintText: "Send a message"),
               ),


### PR DESCRIPTION
Currently, if you activate keyboard (by focusing on TextField) and click on tick button, it still adds empty string to the list.