### PR TITLE
Add omitted "child" to Expanded

### DIFF
--- a/steps/step3_displaying_messages/main.dart
+++ b/steps/step3_displaying_messages/main.dart
@@ -42,7 +42,7 @@ class ChatMessage extends StatelessWidget {
             child: CircleAvatar(child: Text(_name[0])),
           ),
           Expanded(
-            Column(
+            child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                 Text(_name, style: Theme.of(context).textTheme.headline4),

--- a/steps/step4_animate/main.dart
+++ b/steps/step4_animate/main.dart
@@ -47,7 +47,7 @@ class ChatMessage extends StatelessWidget {
                 child: CircleAvatar(child: Text(_name[0])),
               ),
               Expanded(
-                Column(
+                child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                     Text(_name, style: Theme.of(context).textTheme.headline4),


### PR DESCRIPTION
This #96 commit omitted "child" from "Expanded".
